### PR TITLE
add support AEAD encryption functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.2.0] - 2019-04-21
+### Added
+- Add supports AEAD encryption functions
+  - Supported syntax highlighting
+  - Added snippets
+  - Document  
+    https://cloud.google.com/bigquery/docs/reference/standard-sql/aead_encryption_functions
+  - Functions
+
+    |Function Name|Prefix|Body|
+    |:--|:--|:--|
+    |`KEYS.NEW_KEYSET`|`keysnew_keyset`|`KEYS.NEW_KEYSET(key_type)`|
+    |`KEYS.ADD_KEY_FROM_RAW_BYTES`|`keysadd_key_from_raw_bytes`|`KEYS.ADD_KEY_FROM_RAW_BYTES(keyset, key_type, raw_key_bytes)`|
+    |`AEAD.DECRYPT_BYTES`|`aeaddecrypt_bytes`|`AEAD.DECRYPT_BYTES(keyset, ciphertext, additional_data)`|
+    |`AEAD.DECRYPT_STRING`|`aeaddecrypt_string`|`AEAD.DECRYPT_STRING(keyset, ciphertext, additional_data)`|
+    |`AEAD.ENCRYPT`|`aeadencrypt`|`AEAD.ENCRYPT(keyset, plaintext, additional_data)`|
+    |`KEYS.KEYSET_FROM_JSON`|`keyskeyset_from_json`|`KEYS.KEYSET_FROM_JSON(json_keyset)`|
+    |`KEYS.KEYSET_TO_JSON`|`keyskeyset_to_json`|`KEYS.KEYSET_TO_JSON(keyset)`|
+    |`KEYS.ROTATE_KEYSET`|`keysrotate_keyset`|`KEYS.ROTATE_KEYSET(keyset, key_type)`|
+
+### Fixed
+- Miner fixed
+
 ## [1.1.0] - 2019-03-17
 ### Added
 - Initial release
 
+[1.2.0]: https://github.com/shinichi-takii/vscode-language-sql-bigquery/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/shinichi-takii/vscode-language-sql-bigquery/releases/tag/v1.1.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sql-bigquery",
   "displayName": "SQL (BigQuery)",
   "description": "BigQuery SQL language support in Visual Studio Code",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publisher": "shinichi-takii",
   "author": {
     "name": "Shinichi Takii"

--- a/snippets/sql-bigquery.snippets.json
+++ b/snippets/sql-bigquery.snippets.json
@@ -103,7 +103,7 @@
       ]
     },
     "INSERT INTO SELECT": {
-      "prefix": "insertselect",
+      "prefix": "insert select",
       "body": [
         "INSERT INTO `${1:project}.${2:dataset}.${3:table}`",
         "\t(${4:column, ...})",
@@ -146,11 +146,13 @@
         "WHEN MATCHED THEN",
         "\tUPDATE SET ${8:target_column} = ${9:value}",
         "WHEN NOT MATCHED THEN",
-        "\tINSERT (${10:target_column, ...}) VALUES(${11:source_column, ...})"
+        "\tINSERT (${10:target_column, ...}) VALUES(${11:source_column, ...})",
+        "WHEN MATCHED AND ${12:other_condition} THEN",
+        "\tDELETE"
       ]
     },
     "CREATE TABLE": {
-      "prefix": "createtable",
+      "prefix": "create table",
       "body": [
         "CREATE TABLE `${1:project}.${2:dataset}.${3:table}`",
         "(",
@@ -159,7 +161,7 @@
       ]
     },
     "CREATE TABLE IF NOT EXISTS": {
-      "prefix": "createtableifnotexists",
+      "prefix": "create table if not exists",
       "body": [
         "CREATE TABLE IF NOT EXISTS `${1:project}.${2:dataset}.${3:table}`",
         "(",
@@ -168,7 +170,7 @@
       ]
     },
     "CREATE OR REPLACE TABLE": {
-      "prefix": "createorreplacetable",
+      "prefix": "create or replace table",
       "body": [
         "CREATE OR REPLACE TABLE `${1:project}.${2:dataset}.${3:table}`",
         "(",
@@ -1817,6 +1819,38 @@
     "ST_UNION_AGG()": {
       "prefix": "stunionagg",
       "body": "ST_UNION_AGG(${1:geography})"
+    },
+    "KEYS.NEW_KEYSET": {
+      "prefix": "keysnew_keyset",
+      "body": "KEYS.NEW_KEYSET(${1:key_type})"
+    },
+    "KEYS.ADD_KEY_FROM_RAW_BYTES": {
+      "prefix": "keysadd_key_from_raw_bytes",
+      "body": "KEYS.ADD_KEY_FROM_RAW_BYTES(${1:keyset}, ${2:key_type}, ${3:raw_key_bytes})"
+    },
+    "AEAD.DECRYPT_BYTES": {
+      "prefix": "aeaddecrypt_bytes",
+      "body": "AEAD.DECRYPT_BYTES(${1:keyset}, ${2:ciphertext}, ${3:additional_data})"
+    },
+    "AEAD.DECRYPT_STRING": {
+      "prefix": "aeaddecrypt_string",
+      "body": "AEAD.DECRYPT_STRING(${1:keyset}, ${2:ciphertext}, ${3:additional_data})"
+    },
+    "AEAD.ENCRYPT": {
+      "prefix": "aeadencrypt",
+      "body": "AEAD.ENCRYPT(${1:keyset}, ${2:plaintext}, ${3:additional_data})"
+    },
+    "KEYS.KEYSET_FROM_JSON": {
+      "prefix": "keyskeyset_from_json",
+      "body": "KEYS.KEYSET_FROM_JSON(${1:json_keyset})"
+    },
+    "KEYS.KEYSET_TO_JSON": {
+      "prefix": "keyskeyset_to_json",
+      "body": "KEYS.KEYSET_TO_JSON(${1:keyset})"
+    },
+    "KEYS.ROTATE_KEYSET": {
+      "prefix": "keysrotate_keyset",
+      "body": "KEYS.ROTATE_KEYSET(${1:keyset}, ${2:key_type})"
     },
     "INFORMATION_SCHEMA.SCHEMATA": {
       "prefix": "informationschemata",

--- a/syntaxes/sql-bigquery.tmLanguage.json
+++ b/syntaxes/sql-bigquery.tmLanguage.json
@@ -597,6 +597,14 @@
           "name": "support.function.gis.sql"
         },
         {
+          "match": "(?i)\\b(KEYS\\.(NEW_KEYSET|ADD_KEY_FROM_RAW_BYTES|KEYSET_FROM_JSON|KEYSET_TO_JSON|ROTATE_KEYSET))\\b",
+          "name": "support.function.keys.sql"
+        },
+        {
+          "match": "(?i)\\b(AEAD\\.(DECRYPT_BYTES|DECRYPT_STRING|ENCRYPT))\\b",
+          "name": "support.function.aead.sql"
+        },
+        {
           "match": "(?i)\\b(EXACT_COUNT_DISTINCT|FIRST|GROUP_CONCAT(_UNQUOTED)?|LAST|NEST|NTH|QUANTILES|TOP|UNIQUE)(?=\\s*\\()",
           "name": "invalid.deprecated.legacy.aggregate.sql"
         },


### PR DESCRIPTION
## Changes

### Added
- Add supports AEAD encryption functions
  - Supported syntax highlighting
  - Added snippets
  - Document  
    https://cloud.google.com/bigquery/docs/reference/standard-sql/aead_encryption_functions
  - Functions

    |Function Name|Prefix|Body|
    |:--|:--|:--|
    |`KEYS.NEW_KEYSET`|`keysnew_keyset`|`KEYS.NEW_KEYSET(key_type)`|
    |`KEYS.ADD_KEY_FROM_RAW_BYTES`|`keysadd_key_from_raw_bytes`|`KEYS.ADD_KEY_FROM_RAW_BYTES(keyset, key_type, raw_key_bytes)`|
    |`AEAD.DECRYPT_BYTES`|`aeaddecrypt_bytes`|`AEAD.DECRYPT_BYTES(keyset, ciphertext, additional_data)`|
    |`AEAD.DECRYPT_STRING`|`aeaddecrypt_string`|`AEAD.DECRYPT_STRING(keyset, ciphertext, additional_data)`|
    |`AEAD.ENCRYPT`|`aeadencrypt`|`AEAD.ENCRYPT(keyset, plaintext, additional_data)`|
    |`KEYS.KEYSET_FROM_JSON`|`keyskeyset_from_json`|`KEYS.KEYSET_FROM_JSON(json_keyset)`|
    |`KEYS.KEYSET_TO_JSON`|`keyskeyset_to_json`|`KEYS.KEYSET_TO_JSON(keyset)`|
    |`KEYS.ROTATE_KEYSET`|`keysrotate_keyset`|`KEYS.ROTATE_KEYSET(keyset, key_type)`|

### Fixed
- Miner fixed


## Applicable Issues
- fix #1 : Add supports AEAD encryption functions
