### PR TITLE
add support DROP MODEL, enhance CREATE TABLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.3.0] - 2019-07-14
+### Added
+- Add BigQuery ML supports the `DROP MODEL` DDL statement for deleting models.
+
+### Changed
+- Add description option to `CREATE TABLE` statements.
+  - Example
+    - Prefix  
+      `create table`
+    - Body
+      - old
+        ```sql
+        CREATE TABLE `project.dataset.table`
+        (
+          column type
+        )
+        ```
+      - new
+        ```sql
+        CREATE TABLE `project.dataset.table`
+        (
+          column type OPTIONS (description = "comment")
+        )
+        ```
+
+
 ## [1.2.0] - 2019-04-21
 ### Added
 - Add supports AEAD encryption functions
@@ -28,9 +54,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Miner fixed
 
+
 ## [1.1.0] - 2019-03-17
 ### Added
 - Initial release
 
+
+[1.3.0]: https://github.com/shinichi-takii/vscode-language-sql-bigquery/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/shinichi-takii/vscode-language-sql-bigquery/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/shinichi-takii/vscode-language-sql-bigquery/releases/tag/v1.1.0

--- a/snippets/sql-bigquery.snippets.json
+++ b/snippets/sql-bigquery.snippets.json
@@ -156,7 +156,7 @@
       "body": [
         "CREATE TABLE `${1:project}.${2:dataset}.${3:table}`",
         "(",
-        "\t${4:column} ${5:type}",
+        "\t${4:column} ${5:type}${6: OPTIONS (description = \"comment\")}",
         ")"
       ]
     },
@@ -165,7 +165,7 @@
       "body": [
         "CREATE TABLE IF NOT EXISTS `${1:project}.${2:dataset}.${3:table}`",
         "(",
-        "\t${4:column} ${5:type}",
+        "\t${4:column} ${5:type}${6: OPTIONS (description = \"comment\")}",
         ")"
       ]
     },
@@ -174,7 +174,7 @@
       "body": [
         "CREATE OR REPLACE TABLE `${1:project}.${2:dataset}.${3:table}`",
         "(",
-        "\t${4:column} ${5:type}",
+        "\t${4:column} ${5:type}${6: OPTIONS (description = \"comment\")}",
         ")"
       ]
     },
@@ -183,10 +183,10 @@
       "body": [
         "CREATE TABLE `${1:project}.${2:dataset}.${3:table}`",
         "(",
-        "\t${4:column} ${5:type}",
+        "\t${4:column} ${5:type}${6: OPTIONS (description = \"comment\")}",
         ")",
-        "PARTITION BY ${6:DATE(_PARTITIONTIME)|DATE(<timestamp_column>)|<date_column>}",
-        "${7:[CLUSTER BY clustering_column_list]}"
+        "PARTITION BY ${7:DATE(_PARTITIONTIME)|DATE(<timestamp_column>)|<date_column>}",
+        "${8:[CLUSTER BY clustering_column_list]}"
       ]
     },
     "CREATE TABLE AS SELECT": {
@@ -194,12 +194,12 @@
       "body": [
         "CREATE TABLE `${1:project}.${2:dataset}.${3:table}`",
         "(",
-        "\t${4:column} ${5:type}",
+        "\t${4:column} ${5:type}${6: OPTIONS (description = \"comment\")}",
         ") AS",
         "SELECT",
-        "\t${6:column}",
-        "FROM `${7:project}.${8:dataset}.${9:table}`",
-        "WHERE ${10:condition}"
+        "\t${7:column}",
+        "FROM `${8:project}.${9:dataset}.${10:table}`",
+        "WHERE ${11:condition}"
       ]
     },
     "CREATE TABLE OPTIONS": {
@@ -301,6 +301,10 @@
     "DROP VIEW IF EXISTS": {
       "prefix": "drop view if exists",
       "body": "DROP VIEW IF EXISTS `${1:project}.${2:dataset}.${3:view}`"
+    },
+    "DROP MODEL": {
+      "prefix": "drop model",
+      "body": "${1:DROP MODEL | DROP MODEL IF EXISTS} `${2:project}.${3:dataset}.${4:model}`"
     },
     "ALTER TABLE SET OPTIONS": {
       "prefix": "alter table",


### PR DESCRIPTION
## Changes

### Added
- Add BigQuery ML supports the `DROP MODEL` DDL statement for deleting models.

### Changed
- Add description option to `CREATE TABLE` statements.
  - Example
    - Prefix  
      `create table`
    - Body
      - old
        ```sql
        CREATE TABLE `project.dataset.table`
        (
          column type
        )
        ```
      - new
        ```sql
        CREATE TABLE `project.dataset.table`
        (
          column type OPTIONS (description = "comment")
        )
        ```


## Applicable Issues
- fix #3 : Add support 'DROP MODEL' statements
- fix #4 : Add description option to 'CREATE TABLE' statements
