### PR TITLE
Fix 'BEGIN ... END' snippets prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.6.1] - 2021-05-17
+### Fixed
+- Fixed `BEGIN ... END` snippets prefix
+  - `BEGIN ... END`
+    - Prefix  
+      `begin/end` -> `begin end`
+
+
 ## [1.6.0] - 2021-05-16
 ### Added
 - Added supports new **Data types** syntax.
@@ -1945,6 +1953,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 
 
+[1.6.1]: https://github.com/shinichi-takii/vscode-language-sql-bigquery/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/shinichi-takii/vscode-language-sql-bigquery/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/shinichi-takii/vscode-language-sql-bigquery/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/shinichi-takii/vscode-language-sql-bigquery/compare/v1.3.0...v1.4.0

--- a/snippets/sql-bigquery.snippets.json
+++ b/snippets/sql-bigquery.snippets.json
@@ -633,18 +633,18 @@
       "description": "Executes a dynamic SQL statement on the fly."
     },
     "BEGIN ... END": {
-      "prefix": "begin/end",
+      "prefix": "begin end",
       "body": [
         "BEGIN",
         "\t${1:statements}",
+        "",
         "EXCEPTION WHEN ERROR THEN",
-        "\t${2:statements}",
-        "\t${3:[# Get error informations",
+        "\t${2:# Get error informations",
         "\tSELECT",
         "\t\t@@error.message,",
         "\t\t@@error.stack_trace,",
         "\t\t@@error.statement_text,",
-        "\t\t@@error.formatted_stack_trace;]}",
+        "\t\t@@error.formatted_stack_trace;}",
         "END;"
       ]
     },


### PR DESCRIPTION
### Description

- Fix `BEGIN ... END` snippets prefix


#### Fix snippets

- `BEGIN ... END`
  - Prefix  
    `begin/end` -> `begin end`


## Changes

### Fixed
- Fixed `BEGIN ... END` snippets prefix
  `begin/end` -> `begin end`


## Applicable Issues
- fix #33 : Fix 'BEGIN ... END' snippets prefix
