### PR TITLE
Add supports 'ALTER TABLE RENAME TO' statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.7.0] - 2021-05-20
+### Added
+- Added supports `ALTER TABLE RENAME TO` statement snippets.
+  - `ALTER TABLE RENAME TO`
+    - Prefix  
+      `alter table rename`
+    - Body
+      ```sql
+      ALTER TABLE ${1:[IF EXISTS]} `${2:project}.${3:dataset}.${4:table}`
+        RENAME TO ${5:new_table_name}
+      ```
+
+### Fixed
+- Miner fixed
+
+
 ## [1.6.1] - 2021-05-17
 ### Fixed
 - Fixed `BEGIN ... END` snippets prefix
@@ -1953,6 +1969,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 
 
+[1.7.0]: https://github.com/shinichi-takii/vscode-language-sql-bigquery/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/shinichi-takii/vscode-language-sql-bigquery/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/shinichi-takii/vscode-language-sql-bigquery/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/shinichi-takii/vscode-language-sql-bigquery/compare/v1.4.0...v1.5.0

--- a/snippets/sql-bigquery.snippets.json
+++ b/snippets/sql-bigquery.snippets.json
@@ -106,10 +106,6 @@
       ],
       "description": "Filters the results of analytic functions."
     },
-    "DISTINCT": {
-      "prefix": "distinct",
-      "body": "DISTINCT"
-    },
     "PARTITION BY": {
       "prefix": "partitionby",
       "body": [
@@ -195,6 +191,19 @@
         "\t\tIN (${7:unpivot_column, ...})",
         "\t)"
       ]
+    },
+    // Keyword
+    "DISTINCT": {
+      "prefix": "distinct",
+      "body": "DISTINCT"
+    },
+    "NULL": {
+      "prefix": "null",
+      "body": "NULL"
+    },
+    "ON": {
+      "prefix": "on",
+      "body": "ON"
     },
     // DML
     "INSERT INTO": {
@@ -537,6 +546,13 @@
         "\tfriendly_name = \"friendly_name\",",
         "\tlabels = [(\"key\", \"value\")]}",
         ")"
+      ]
+    },
+    "ALTER TABLE RENAME TO": {
+      "prefix": "alter table rename",
+      "body": [
+        "ALTER TABLE ${1:[IF EXISTS]} `${2:project}.${3:dataset}.${4:table}`",
+        "\tRENAME TO ${5:new_table_name}"
       ]
     },
     "ALTER TABLE ADD COLUMN": {

--- a/syntaxes/sql-bigquery.tmLanguage.json
+++ b/syntaxes/sql-bigquery.tmLanguage.json
@@ -202,7 +202,7 @@
       "name": "keyword.other.DML.sql"
     },
     {
-      "match": "(?i:\\b(create(\\s+(temporary|temp))?|drop(\\s+column)?|schema|table|view|materialized(\\s+view)?|external\\s+table|if|not|exists|partition|cluster|options|rows|range|unbounded|preceding|following|current|row|returns|language|deterministic|(\\s*or\\s+replace\\s+)?(function|procedure|model)(\\s*if\\s+not\\s+exists\\s+)?|(add|drop)\\s+column|cascade|restrict)\\b)",
+      "match": "(?i:\\b(create(\\s+(temporary|temp))?|drop(\\s+column)?|schema|table|view|materialized(\\s+view)?|external\\s+table|if|not|exists|partition|cluster|options|rows|range|unbounded|preceding|following|current|row|returns|language|deterministic|(\\s*or\\s+replace\\s+)?(function|procedure|model)(\\s*if\\s+not\\s+exists\\s+)?|(add|drop)\\s+column|cascade|restrict|rename|to)\\b)",
       "name": "keyword.other.DDL.sql"
     },
     {


### PR DESCRIPTION
## Changes

### Added
- Added supports `ALTER TABLE RENAME TO` statement snippets.
  - `ALTER TABLE RENAME TO`
    - Prefix  
      `alter table rename`
    - Body
      ```sql
      ALTER TABLE ${1:[IF EXISTS]} `${2:project}.${3:dataset}.${4:table}`
        RENAME TO ${5:new_table_name}
      ```

### Fixed
- Miner fixed


## Applicable Issues
- fix #35 : Add supports 'ALTER TABLE RENAME TO' statement
